### PR TITLE
Add domain to Person constructor, fix Attribute generation defaults

### DIFF
--- a/AttributeGenerator/Program.cs
+++ b/AttributeGenerator/Program.cs
@@ -138,7 +138,7 @@ namespace ChanceNET
 					{
 						defaultValue = paramType.Name + "." + defaultValue;
 					}
-					if (paramType == typeof(string))
+					if (paramType == typeof(string) && !defaultValue.ToString().Equals("null"))
 					{
 						defaultValue = "\"" + defaultValue + "\"";
 					}

--- a/Chance.NET/Attributes/Generated/DomainAttribute.Generated.cs
+++ b/Chance.NET/Attributes/Generated/DomainAttribute.Generated.cs
@@ -13,7 +13,7 @@ namespace ChanceNET.Attributes
 		String tld = null;
 
 
-		public DomainAttribute(String tld = "null")
+		public DomainAttribute(String tld = null)
 		{
 			this.tld = tld;
 

--- a/Chance.NET/Attributes/Generated/EmailAttribute.Generated.cs
+++ b/Chance.NET/Attributes/Generated/EmailAttribute.Generated.cs
@@ -15,7 +15,7 @@ namespace ChanceNET.Attributes
 		String tld = null;
 
 
-		public EmailAttribute(Int32 length = 0, String domain = "null", String tld = "null")
+		public EmailAttribute(Int32 length = 0, String domain = null, String tld = null)
 		{
 			this.length = length;
 			this.domain = domain;

--- a/Chance.NET/Attributes/Generated/EndPointAttribute.Generated.cs
+++ b/Chance.NET/Attributes/Generated/EndPointAttribute.Generated.cs
@@ -14,7 +14,7 @@ namespace ChanceNET.Attributes
 		UInt16 port = 0;
 
 
-		public EndPointAttribute(String subnet = "null", UInt16 port = 0)
+		public EndPointAttribute(String subnet = null, UInt16 port = 0)
 		{
 			this.subnet = subnet;
 			this.port = port;

--- a/Chance.NET/Attributes/Generated/FloatAttribute.Generated.cs
+++ b/Chance.NET/Attributes/Generated/FloatAttribute.Generated.cs
@@ -8,22 +8,22 @@ using System.Threading.Tasks;
 namespace ChanceNET.Attributes
 {
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-	public class PhoneAttribute : ChanceAttribute
+	public class FloatAttribute : ChanceAttribute
 	{
-		String areaCode = null;
-		Boolean formatted = true;
+		Single min = 0;
+		Single max = 1;
 
 
-		public PhoneAttribute(String areaCode = null, Boolean formatted = true)
+		public FloatAttribute(Single min = 0, Single max = 1)
 		{
-			this.areaCode = areaCode;
-			this.formatted = formatted;
+			this.min = min;
+			this.max = max;
 
 		}
 
 		internal override object GetValue(Chance chance)
 		{
-			return chance.Phone(areaCode, formatted);
+			return chance.Float(min, max);
 		}
 	}
 }

--- a/Chance.NET/Attributes/Generated/IPAttribute.Generated.cs
+++ b/Chance.NET/Attributes/Generated/IPAttribute.Generated.cs
@@ -13,7 +13,7 @@ namespace ChanceNET.Attributes
 		String subnet = null;
 
 
-		public IPAttribute(String subnet = "null")
+		public IPAttribute(String subnet = null)
 		{
 			this.subnet = subnet;
 

--- a/Chance.NET/Attributes/Generated/PersonAttribute.Generated.cs
+++ b/Chance.NET/Attributes/Generated/PersonAttribute.Generated.cs
@@ -12,18 +12,20 @@ namespace ChanceNET.Attributes
 	{
 		AgeRanges ageRange = (AgeRanges)~0;
 		Gender gender = (Gender)~0;
+		String emailDomain = null;
 
 
-		public PersonAttribute(AgeRanges ageRange = (AgeRanges)~0, Gender gender = (Gender)~0)
+		public PersonAttribute(AgeRanges ageRange = (AgeRanges)~0, Gender gender = (Gender)~0, String emailDomain = null)
 		{
 			this.ageRange = ageRange;
 			this.gender = gender;
+			this.emailDomain = emailDomain;
 
 		}
 
 		internal override object GetValue(Chance chance)
 		{
-			return chance.Person(ageRange, gender);
+			return chance.Person(ageRange, gender, emailDomain);
 		}
 	}
 }

--- a/Chance.NET/Attributes/Generated/UrlAttribute.Generated.cs
+++ b/Chance.NET/Attributes/Generated/UrlAttribute.Generated.cs
@@ -16,7 +16,7 @@ namespace ChanceNET.Attributes
 		String extension = null;
 
 
-		public UrlAttribute(String scheme = "null", String domain = "null", String path = "null", String extension = "null")
+		public UrlAttribute(String scheme = null, String domain = null, String path = null, String extension = null)
 		{
 			this.scheme = scheme;
 			this.domain = domain;

--- a/Chance.NET/Chance.cs
+++ b/Chance.NET/Chance.cs
@@ -585,10 +585,11 @@ namespace ChanceNET
 		/// </summary>
 		/// <param name="ageRange"></param>
 		/// <param name="gender">Pick for a specific gender. Default is any.</param>
+		/// <param name="emailDomain">Set for a specific email domain. Default is to generate a random domain.</param>
 		/// <returns></returns>
-		public Person Person(AgeRanges ageRange = AgeRanges.Any, Gender gender = (Gender)~0)
+		public Person Person(AgeRanges ageRange = AgeRanges.Any, Gender gender = (Gender)~0, string emailDomain = null)
 		{
-			return new Person(this, ageRange, gender);
+			return new Person(this, ageRange, gender, emailDomain);
 		}
 
 		/// <summary>

--- a/Chance.NET/Classes/Person.cs
+++ b/Chance.NET/Classes/Person.cs
@@ -38,7 +38,7 @@ namespace ChanceNET
 			}
 		}
 
-		internal Person(Chance chance, AgeRanges ageRange = AgeRanges.Any, Gender? gender = null)
+		internal Person(Chance chance, AgeRanges ageRange = AgeRanges.Any, Gender? gender = null, string emailDomain = null)
 		{
 			Gender = gender ?? chance.Gender();
 
@@ -50,7 +50,7 @@ namespace ChanceNET
 			SSN			= chance.SSN();
 			Birthday	= chance.Birthday(ageRange);
 			Phone		= chance.Phone();
-			Email       = chance.Email();
+			Email       = chance.Email(domain: emailDomain);
 		}
 
 		public string FullName(bool prefix = false, bool middle = false, bool middleInitial = false, bool suffix = false)


### PR DESCRIPTION
We wanted to be able to use the `Person` struct for our integration tests but needed to be able to set the email domain, so this update is to be able to do that. I also updated the AttributeGenerator to pass actual nulls through instead of `"null"` as a string and re-ran it, which also created the `FloatAttribute`.